### PR TITLE
Revert "gopeed: Update gopeed.deb to 1.6.2"

### DIFF
--- a/com.gopeed.Gopeed.metainfo.xml
+++ b/com.gopeed.Gopeed.metainfo.xml
@@ -21,11 +21,8 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="1.6.2" date="2024-11-15">
-      <description></description>
-    </release>
     <release version="1.6.1" date="2024-10-16">
-      <description/>
+      <description></description>
     </release>
     <release version="1.6.0" date="2024-09-21">
       <description/>

--- a/com.gopeed.Gopeed.yaml
+++ b/com.gopeed.Gopeed.yaml
@@ -37,9 +37,9 @@ modules:
       - install -Dm644 com.gopeed.Gopeed.metainfo.xml -t /app/share/metainfo
     sources:
       - type: file
-        url: https://github.com/GopeedLab/gopeed/releases/download/v1.6.2/Gopeed-v1.6.2-linux-amd64.deb
+        url: https://github.com/GopeedLab/gopeed/releases/download/v1.6.1/Gopeed-v1.6.1-linux-amd64.deb
         dest-filename: gopeed.deb
-        sha256: c26f46354abfa289e9152674559cec5dc194abebfef02cba16c4e01f0fd6e4ef
+        sha256: b44f8cf88dba9197087a037540fe92dfed8207818fd6ffa3452a14cabacf4541
         x-checker-data:
           type: json
           url: https://api.github.com/repos/GopeedLab/gopeed/releases/latest


### PR DESCRIPTION
Reverts flathub/com.gopeed.Gopeed#17 due to https://github.com/GopeedLab/gopeed/issues/814